### PR TITLE
Credentials.php updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 codelab/
 test.php
 aws-tokens
+.idea

--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ Name  | Description  |  Type
 
   //Create Credentials service and call getCredentials() to obtain
   //all the tokens needed under the hood
-  $credentials = new DoubleBreak\Spapi\Credentials($tokenStorage, $signer, $config);
+
+  $for_api = ''; 
+  //default value for $for_api = '';
+  // '' : credentials for authorized api requests e.g. Orders API, Catalog API, etc.// 
+  //'authorization_api' : credentials for grantless operation for Authorization API.
+  //'notification_api' : credentials for grantless operation for Notification API.
+  $credentials = new DoubleBreak\Spapi\Credentials($tokenStorage, $signer, $config, $for_api);
   $cred = $credentials->getCredentials();
 
 

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
   "require": {
     "guzzlehttp/guzzle": "^6.5",
     "guzzlehttp/psr7": "^1.7",
-    "patchwork/utf8": "~1.2",
     "ext-simplexml": "*",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-zlib": "*"
   },
   "autoload": {
     "psr-4": { "DoubleBreak\\Spapi\\" : "src/" }

--- a/src/Helper/Feeder.php
+++ b/src/Helper/Feeder.php
@@ -10,7 +10,6 @@ namespace DoubleBreak\Spapi\Helper;
 use DoubleBreak\Spapi\ASECryptoStream;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
-use Patchwork\Utf8;
 
 class Feeder
 {
@@ -44,7 +43,7 @@ class Feeder
         }
 
         // utf8 !
-        $file = Utf8::utf8_encode($file);
+        $file = utf8_encode($file);
 
         // encrypt string and get value as base64 encoded string
         $encryptedFile = ASECryptoStream::encrypt($file, $key, $initializationVector);
@@ -90,6 +89,9 @@ class Feeder
         $key = base64_decode($key, true);
 
         $decryptedFile = ASECryptoStream::decrypt(file_get_contents($feedDownloadUrl), $key, $initializationVector);
+        if($payload['compressionAlgorithm']=='GZIP') {
+            $decryptedFile=gzdecode($decryptedFile);
+        }
         $decryptedFile = preg_replace('/\s+/S', " ", $decryptedFile);
 
         $xml = simplexml_load_string($decryptedFile);


### PR DESCRIPTION
Credentials.php updated for generating credentials based on the type of operation like Grantless or Authorized.

For Notification and Authorization API function calls are Grantless and all other API calls need to be authorized by the seller. 

So now for the credentials class construct function, the user has to pass one extra parameter $for_api based on Grantless API operations for others function call remain same.
like: 
   $credentials = new Credentials($tokenStorage, $signer, $config);

for Authorization API $for_api = 'authorization_api' and Notification API $for_api = 'notification_api'.
   $credentials = new Credentials($tokenStorage, $signer, $config, $for_api);
