### PR TITLE
Fix handling of streams in feed uploads

### DIFF
--- a/src/Helper/Feeder.php
+++ b/src/Helper/Feeder.php
@@ -34,12 +34,13 @@ class Feeder
         $key = base64_decode($key, true);
 
         // get file to upload
-        $file = file_get_contents($feedContentFilePath);
-        $fileResourceType = gettype($file);
+        $fileResourceType = gettype($feedContentFilePath);
 
         // resource or string ? make it to a string
         if ($fileResourceType == 'resource') {
-            $file = stream_get_contents($file);
+            $file = stream_get_contents($feedContentFilePath);
+        } else {
+            $file = file_get_contents($feedContentFilePath);
         }
 
         // utf8 !


### PR DESCRIPTION
This changes the uploadFeedDocument function to correctly handle a stream resource in the `feedContentFilePath` parameter. Previously, it would trigger a TypeError when calling `file_get_contents`.

If this is working correctly in some way already, I may be misunderstanding how this is meant to be used, but this fixed the issue for me.