### PR TITLE
Fix deprecated ternary usage

### DIFF
--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -29,7 +29,8 @@ class Credentials
      */
     public function getCredentials($useMigrationToken = false)
     {
-        $lwaAccessToken = $useMigrationToken === true ? $this->getMigrationToken() : $useMigrationToken === 'grantless' ? $this->getGrantlessAuthToken() : $this->getLWAToken();
+        $lwaAccessToken = $useMigrationToken === true ? $this->getMigrationToken() :
+            ($useMigrationToken === 'grantless' ? $this->getGrantlessAuthToken() : $this->getLWAToken());
         $stsCredentials = $this->getStsTokens();
 
         return [


### PR DESCRIPTION
This fixes the deprecated ternary usage in `Credentials.php`, which causes issues running this on recent PHP versions.

Fixes #26