### PR TITLE
Update composer config to depend on newer version of guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "ext-json": "*",
     "ext-zlib": "*",
     "guzzlehttp/guzzle": "^7.4",
-    "guzzlehttp/psr7": "^2.1"
+    "guzzlehttp/psr7": "^2.4"
   },
   "autoload": {
     "psr-4": { "DoubleBreak\\Spapi\\" : "src/" }


### PR DESCRIPTION
The latest version of guzzlehttp/psr7 is 2.4. 

I can see that the main branch is currently targeting ^2.1. I think cutting a new release will help resolve issues where people are attempting to target 2.x of guzzlehttp/psr7.